### PR TITLE
feat: add optimised Docker image (Chromium-only, ~400-600 MB)

### DIFF
--- a/.changeset/docker-image.md
+++ b/.changeset/docker-image.md
@@ -1,0 +1,31 @@
+---
+"@slashgear/gdpr-cookie-scanner": minor
+---
+
+feat: add Docker image for containerised usage
+
+A `Dockerfile` is now included at the root of the repository, enabling
+`gdpr-scan` to be run in any environment that supports Docker without
+needing a local Node.js or Playwright installation.
+
+The image uses a two-stage build:
+
+- **Builder** (`node:24-slim`) — compiles TypeScript to `dist/`
+- **Runtime** (`node:24-slim` + `playwright install chromium --with-deps`) —
+  installs only Chromium and its system dependencies instead of the full
+  official Playwright image (which bundles Chromium, Firefox and WebKit).
+  This keeps the final image around **400–600 MB** vs ~1.5–1.8 GB for the
+  unoptimised approach.
+
+A `.dockerignore` is also included to exclude source files, Git history,
+and dev artefacts from the build context.
+
+Usage:
+
+```bash
+# Build
+docker build -t gdpr-scan .
+
+# Run a scan (mount a local directory to retrieve the reports)
+docker run --rm -v $(pwd)/reports:/reports gdpr-scan scan https://example.com -o /reports
+```

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,13 @@
+.git
+.github
+.claude
+.changeset
 node_modules/
 dist/
-.changeset/
-.claude/
-tests/
+reports/
 gdpr-reports/
+tests/
+*.md
 *.log
 .DS_Store
 .nvmrc


### PR DESCRIPTION
## Summary

- Adds a `Dockerfile` at the repository root using a two-stage build
- Runtime stage uses `node:24-slim` + `playwright install chromium --with-deps` instead of the full `mcr.microsoft.com/playwright` image
- Final image is **~400–600 MB** vs ~1.5–1.8 GB (avoids bundling Firefox + WebKit)
- Adds `.dockerignore` to exclude source files, Git history and dev artefacts from the build context
- Adds a `minor` changeset documenting the new Docker image and its usage

## Usage

```bash
# Build
docker build -t gdpr-scan .

# Run a scan
docker run --rm -v $(pwd)/reports:/reports gdpr-scan scan https://example.com -o /reports
```

## Test plan

- [x] `docker build -t gdpr-scan .` completes without errors
- [x] `docker run --rm gdpr-scan --help` prints the help output
- [x] `docker run --rm -v $(pwd)/reports:/reports gdpr-scan scan https://example.com -o /reports` produces reports in the mounted volume
- [x] CI lint / typecheck / format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)